### PR TITLE
Updated nunjucks to v2.2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function render(source, config) {
   config = config || {};
   config.raml2MdVersion = pjson.version;
 
-  var env = nunjucks.configure(config.templatesPath, {watch: false});
+  var env = nunjucks.configure(config.templatesPath, {autoescape: false});
 
   return raml2obj.parse(source).then(function(ramlObj) {
     ramlObj.config = config;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "commander": "2.8.x",
-    "nunjucks": "1.3.x",
+    "nunjucks": "2.2.x",
     "raml2obj": "2.2.x",
     "q": "1.4.x"
   },


### PR DESCRIPTION
I updated Nunjucks because of the change in [#559](https://github.com/mozilla/nunjucks/pull/559) to optionally suppress errors if the template does not exist. In practice we wanna use it to include code examples if the example file exists.

Major changes from 1.3 to 2.2 are that [watch is now off by default, autoescape is on](https://github.com/mozilla/nunjucks/blob/master/CHANGELOG.md#v200-aug-30-2015). I regenerated the example template by `bin/raml2md -i examples/example.raml -o examples/example.md`. No change is visible, so I assume all other stuff still works.